### PR TITLE
Changed to volatility3 stable branch

### DIFF
--- a/pdbconv/Dockerfile
+++ b/pdbconv/Dockerfile
@@ -43,7 +43,7 @@ RUN apk add --no-cache                  \
     python3-dev
 
 # Install the Volatility 3 framework
-RUN git clone https://github.com/volatilityfoundation/volatility3.git && \
+RUN git clone https://github.com/volatilityfoundation/volatility3.git --single-branch --branch stable --depth 1 && \
     cd volatility3                                                    && \
     python3 setup.py install                                          && \
     ln -sf ${DEF_INSTALL_PREFIX}/bin/vol ${DEF_INSTALL_PREFIX}/bin/volatility

--- a/pdbconv/Dockerfile
+++ b/pdbconv/Dockerfile
@@ -40,7 +40,8 @@ RUN apk add --no-cache                  \
     gcc                                 \
     git                                 \
     musl-dev                            \
-    python3-dev
+    python3-dev                      && \
+    python3 -m ensurepip --default-pip
 
 # Install the Volatility 3 framework
 RUN git clone https://github.com/volatilityfoundation/volatility3.git --single-branch --branch stable --depth 1 && \

--- a/volatility/Dockerfile
+++ b/volatility/Dockerfile
@@ -80,7 +80,7 @@ RUN find . -type d -exec chmod 755 {} \; && \
     find . -type f -exec chmod 644 {} \;
 
 # Install the Volatility 3 framework
-RUN git clone https://github.com/volatilityfoundation/volatility3.git && \
+RUN git clone https://github.com/volatilityfoundation/volatility3.git --single-branch --branch stable --depth 1 && \
     cd volatility3                                                    && \
     python3 setup.py install                                          && \
     ln -sf ${DEF_INSTALL_PREFIX}/bin/vol ${DEF_INSTALL_PREFIX}/bin/volatility

--- a/volatility/Dockerfile
+++ b/volatility/Dockerfile
@@ -35,7 +35,8 @@ RUN apk add --no-cache --virtual .build \
     git                                 \
     musl-dev                            \
     python3-dev                         \
-    unzip
+    unzip                            && \
+    python3 -m ensurepip --default-pip
 
 # Build the Python bindings for YARA
 RUN git clone --recursive https://github.com/VirusTotal/yara-python && \
@@ -72,7 +73,8 @@ WORKDIR ${DEF_INSTALL_PREFIX}/lib
 RUN apk add --no-cache                  \
     python3                          && \
     apk add --no-cache --virtual .build \
-    git
+    git                              && \
+    python3 -m ensurepip --default-pip
 
 COPY --from=builder --chown="${DEF_USERNAME}:${DEF_USERNAME}" /tmp/build/yara-python yara-python
 

--- a/volshell/Dockerfile
+++ b/volshell/Dockerfile
@@ -78,7 +78,7 @@ RUN find . -type d -exec chmod 755 {} \; && \
     find . -type f -exec chmod 644 {} \;
 
 # Install the Volatility 3 framework
-RUN git clone https://github.com/volatilityfoundation/volatility3.git && \
+RUN git clone https://github.com/volatilityfoundation/volatility3.git --single-branch --branch stable --depth 1 && \
     cd volatility3                                                    && \
     python3 setup.py install                                          && \
     ln -sf ${DEF_INSTALL_PREFIX}/bin/vol ${DEF_INSTALL_PREFIX}/bin/volatility

--- a/volshell/Dockerfile
+++ b/volshell/Dockerfile
@@ -33,7 +33,8 @@ RUN apk add --no-cache --virtual .build \
     git                                 \
     musl-dev                            \
     python3-dev                         \
-    unzip
+    unzip                            && \
+    python3 -m ensurepip --default-pip
 
 # Build the Python bindings for YARA
 RUN git clone --recursive https://github.com/VirusTotal/yara-python && \
@@ -70,7 +71,8 @@ WORKDIR ${DEF_INSTALL_PREFIX}/lib
 RUN apk add --no-cache                  \
     python3                          && \
     apk add --no-cache --virtual .build \
-    git
+    git                              && \
+    python3 -m ensurepip --default-pip
 
 COPY --from=builder --chown="${DEF_USERNAME}:${DEF_USERNAME}" /tmp/build/yara-python yara-python
 


### PR DESCRIPTION
Hello! We tried to rebuild the image but failed. Here's some tweaks we made to make it work.

One of the big changes is that your Dockerfile is cloning the default branch, which by today is the pre-release of volatility3 v2.0.0, while your Dockerfile is tailored to build volatility3 v1.x.x. 