### PR TITLE
Annual Update 🚀

### DIFF
--- a/.github/workflows/dwarf2json.yml
+++ b/.github/workflows/dwarf2json.yml
@@ -46,7 +46,6 @@ jobs:
           context: src/dwarf2json
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:${{ env.DOCKER_TAG_DWARF2JSON }}
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:${{ env.DOCKER_TAG_DWARF2JSON }}
             ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:stable

--- a/.github/workflows/dwarf2json.yml
+++ b/.github/workflows/dwarf2json.yml
@@ -47,6 +47,10 @@ jobs:
           platforms: linux/amd64,linux/arm64/v8
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:${{ env.DOCKER_TAG_DWARF2JSON }}
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:${{ env.DOCKER_TAG_DWARF2JSON }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:stable
+            ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:latest
           build-args: |
             DOCKER_TAG_ALPINE=${{ env.DOCKER_TAG_ALPINE }}
             GIT_TAG_DWARF2JSON=${{ env.GIT_TAG_DWARF2JSON }}

--- a/.github/workflows/volatility-edge.yml
+++ b/.github/workflows/volatility-edge.yml
@@ -15,10 +15,8 @@ on:
 env:
   # Stuck at this minor version since Alpine Linux no longer distributes Python 2 through its official repositories.
   DOCKER_TAG_ALPINE: "3.15"
-  # No new tags/releases declared in the repository so we use the `edge` tag that follows the main development branch.
   DOCKER_TAG_VOLATILITY: edge
-  GIT_TAG_PYTHON_YARA: v4.5.0
-  # No new tags/releases declared in the repository so we use the development branch.
+  GIT_TAG_PYTHON_YARA: v4.5.1
   GIT_TAG_VOLATILITY: master
   # No new tags/releases declared in the repository so we use the development branch.
   GIT_TAG_VOLATILITY_COMMUNITY: master

--- a/.github/workflows/volatility.yml
+++ b/.github/workflows/volatility.yml
@@ -1,4 +1,4 @@
-name: volatility-edge
+name: volatility
 
 on:
   workflow_dispatch:

--- a/.github/workflows/volatility.yml
+++ b/.github/workflows/volatility.yml
@@ -50,7 +50,10 @@ jobs:
           context: src/volatility
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/volatility:${{ env.DOCKER_TAG_VOLATILITY }}
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/volatility:${{ env.DOCKER_TAG_VOLATILITY }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/volatility:stable
+            ${{ secrets.DOCKER_HUB_USERNAME }}/volatility:latest
           build-args: |
             DOCKER_TAG_ALPINE=${{ env.DOCKER_TAG_ALPINE }}
             GIT_TAG_PYTHON_YARA=${{ env.GIT_TAG_PYTHON_YARA }}

--- a/.github/workflows/volatility.yml
+++ b/.github/workflows/volatility.yml
@@ -1,4 +1,4 @@
-name: dwarf2json
+name: volatility-edge
 
 on:
   workflow_dispatch:
@@ -8,14 +8,18 @@ on:
       - master
       - staging
     paths:
-      - .github/workflows/dwarf2json.yml
-      - src/dwarf2json/**
+      - .github/workflows/volatility.yml
+      - src/volatility/**
       - README.md
 
 env:
-  DOCKER_TAG_ALPINE: latest
-  DOCKER_TAG_DWARF2JSON: "0.9.0"
-  GIT_TAG_DWARF2JSON: v0.9.0
+  # Stuck at this minor version since Alpine Linux no longer distributes Python 2 through its official repositories.
+  DOCKER_TAG_ALPINE: "3.15"
+  DOCKER_TAG_VOLATILITY: "2.6.1"
+  GIT_TAG_PYTHON_YARA: v4.5.1
+  GIT_TAG_VOLATILITY: "2.6.1"
+  # No new tags/releases declared in the repository so we use the development branch.
+  GIT_TAG_VOLATILITY_COMMUNITY: master
 
 jobs:
   docker:
@@ -40,23 +44,25 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
-      - name: Build and push ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json
+      - name: Build and push ${{ secrets.DOCKER_HUB_USERNAME }}/volatility
         uses: docker/build-push-action@v5
         with:
-          context: src/dwarf2json
+          context: src/volatility
           platforms: linux/amd64,linux/arm64/v8
           push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json:${{ env.DOCKER_TAG_DWARF2JSON }}
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/volatility:${{ env.DOCKER_TAG_VOLATILITY }}
           build-args: |
             DOCKER_TAG_ALPINE=${{ env.DOCKER_TAG_ALPINE }}
-            GIT_TAG_DWARF2JSON=${{ env.GIT_TAG_DWARF2JSON }}
+            GIT_TAG_PYTHON_YARA=${{ env.GIT_TAG_PYTHON_YARA }}
+            GIT_TAG_VOLATILITY=${{ env.GIT_TAG_VOLATILITY }}
+            GIT_TAG_VOLATILITY_COMMUNITY=${{ env.GIT_TAG_VOLATILITY_COMMUNITY }}
             PRODUCT_BUILD_COMMIT=${{ github.sha }}
             PRODUCT_BUILD_DATE=${{ steps.date.outputs.date }}
 
-      - name: Update Docker Hub repository description for ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json
+      - name: Update Docker Hub repository description for ${{ secrets.DOCKER_HUB_USERNAME }}/volatility
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          repository: ${{ secrets.DOCKER_HUB_USERNAME }}/dwarf2json
+          repository: ${{ secrets.DOCKER_HUB_USERNAME }}/volatility
           short-description: ${{ github.event.repository.description }}

--- a/.github/workflows/volatility3-edge.yml
+++ b/.github/workflows/volatility3-edge.yml
@@ -19,7 +19,7 @@ env:
   DOCKER_TAG_VOLATILITY3: edge
   # No tags/releases declared in the repository so we use the development branch.
   GIT_TAG_JPCERT_SYMBOLS: main
-  GIT_TAG_PYTHON_YARA: v4.5.0
+  GIT_TAG_PYTHON_YARA: v4.5.1
   GIT_TAG_VOLATILITY3: develop
   # No tags/releases declared in the repository so we use the development branch.
   GIT_TAG_VOLATILITY3_COMMUNITY: master

--- a/.github/workflows/volatility3.yml
+++ b/.github/workflows/volatility3.yml
@@ -16,11 +16,11 @@ on:
 
 env:
   DOCKER_TAG_ALPINE: latest
-  DOCKER_TAG_VOLATILITY3: "2.7.0"
+  DOCKER_TAG_VOLATILITY3: "2.11.0"
   # No tags/releases declared in the repository so we use the development branch.
   GIT_TAG_JPCERT_SYMBOLS: main
-  GIT_TAG_PYTHON_YARA: v4.5.0
-  GIT_TAG_VOLATILITY3: v2.7.0
+  GIT_TAG_PYTHON_YARA: v4.5.1
+  GIT_TAG_VOLATILITY3: v2.11.0
   # No tags/releases declared in the repository so we use the development branch.
   GIT_TAG_VOLATILITY3_COMMUNITY: master
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ By the way, [why are these images not (yet) official?](https://github.com/volati
 
 ## What's in the box?
 
-- [`sk4la/volatility3`](https://hub.docker.com/r/sk4la/volatility) ⭐ (version [2.7.0](https://github.com/volatilityfoundation/volatility3/releases/tag/v2.7.0) from May 29, 2024)
+- [`sk4la/volatility3`](https://hub.docker.com/r/sk4la/volatility3) ⭐ (version [2.11.0](https://github.com/volatilityfoundation/volatility3/releases/tag/v2.11.0) from Jan 16, 2025)
   - The latest release of the official [Volatility 3](https://github.com/volatilityfoundation/volatility3) project
   - The [community-maintained plugins](https://github.com/volatilityfoundation/community3) for Volatility 3
+
+> Since many community plugins are either one-time proof-of-concept contributions or are maintained independently by their respective authors, this image includes only the code explicitly referenced by the [volatilityfoundation/community3](https://github.com/volatilityfoundation/community3) repository.
+
   - The [official symbol tables](https://github.com/volatilityfoundation/volatility3#symbol-tables) for Windows, macOS and GNU/Linux provided by the Volatility Foundation
   - The [symbol tables](https://github.com/JPCERTCC/Windows-Symbol-Tables) provided by the [JPCERT/CC](https://www.jpcert.or.jp/) for the ongoing Windows 11+ support
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By the way, [why are these images not (yet) official?](https://github.com/volati
   - The latest release of the official [Volatility 3](https://github.com/volatilityfoundation/volatility3) project
   - The [community-maintained plugins](https://github.com/volatilityfoundation/community3) for Volatility 3
 
-> Since many community plugins are either one-time proof-of-concept contributions or are maintained independently by their respective authors, this image includes only the code explicitly referenced by the [volatilityfoundation/community3](https://github.com/volatilityfoundation/community3) repository.
+> :warning: Since many community plugins are either one-time proof-of-concept contributions or are maintained independently by their respective authors, this image includes only the code explicitly referenced by the [volatilityfoundation/community3](https://github.com/volatilityfoundation/community3) repository—which does not necessarily include the actual code for the referenced plugins.
 
   - The [official symbol tables](https://github.com/volatilityfoundation/volatility3#symbol-tables) for Windows, macOS and GNU/Linux provided by the Volatility Foundation
   - The [symbol tables](https://github.com/JPCERTCC/Windows-Symbol-Tables) provided by the [JPCERT/CC](https://www.jpcert.or.jp/) for the ongoing Windows 11+ support

--- a/src/volatility3/Dockerfile
+++ b/src/volatility3/Dockerfile
@@ -110,8 +110,12 @@ RUN git clone --branch="${GIT_TAG_VOLATILITY3}" --depth=1 --single-branch \
 
 WORKDIR "${INSTALL_PREFIX}/lib/volatility3"
 
-RUN python3 -m pip install --break-system-packages build && \
-    python3 -m build && \
+RUN if [[ "${GIT_TAG_VOLATILITY3}" == "develop" ]]; then \
+    python3 -m pip install --break-system-packages build; else \
+    python3 -m pip install --break-system-packages --requirement requirements.txt; fi && \
+    if [[ "${GIT_TAG_VOLATILITY3}" == "develop" ]]; then \
+    python3 -m build; else \
+    python3 setup.py install; fi && \
     chmod 0755 \
         vol.py \
         volatility3/framework/symbols/windows/pdbconv.py && \

--- a/src/volatility3/Dockerfile
+++ b/src/volatility3/Dockerfile
@@ -110,8 +110,8 @@ RUN git clone --branch="${GIT_TAG_VOLATILITY3}" --depth=1 --single-branch \
 
 WORKDIR "${INSTALL_PREFIX}/lib/volatility3"
 
-RUN python3 -m pip install --break-system-packages --requirement requirements.txt && \
-    python3 setup.py install && \
+RUN python3 -m pip install --break-system-packages build && \
+    python3 -m build && \
     chmod 0755 \
         vol.py \
         volatility3/framework/symbols/windows/pdbconv.py && \


### PR DESCRIPTION
Bump versions

- Bump `volatility3` to 2.11.0
- Created a new `volatility` pipeline for the last versioned release (different from the original edge pipeline)
- Bump `dwarf2json` to 0.9.0