### PR TITLE
fix(docker): Resolve build failures and runtime permission errors

### DIFF
--- a/src/volatility3/Dockerfile
+++ b/src/volatility3/Dockerfile
@@ -111,11 +111,13 @@ RUN git clone --branch="${GIT_TAG_VOLATILITY3}" --depth=1 --single-branch \
 WORKDIR "${INSTALL_PREFIX}/lib/volatility3"
 
 RUN if [[ "${GIT_TAG_VOLATILITY3}" == "develop" ]]; then \
-    python3 -m pip install --break-system-packages build; else \
-    python3 -m pip install --break-system-packages --requirement requirements.txt; fi && \
-    if [[ "${GIT_TAG_VOLATILITY3}" == "develop" ]]; then \
-    python3 -m build; else \
-    python3 setup.py install; fi && \
+    python3 -m pip install --break-system-packages build; \
+    python3 -m build; \
+    else \
+    
+    python3 -m pip install --break-system-packages .; \
+    fi && \
+    
     chmod 0755 \
         vol.py \
         volatility3/framework/symbols/windows/pdbconv.py && \
@@ -170,7 +172,10 @@ COPY --chown=root:root \
          assets/aliases.sh \
          /etc/profile.d/
 
-WORKDIR "${INSTALL_PREFIX}"
+RUN mkdir -p /workspace && \
+    chown "${INSTALL_USER}:${INSTALL_GROUP}" /workspace
+WORKDIR /workspace
+
 
 USER "${INSTALL_USER}"
 

--- a/src/volatility3/Dockerfile
+++ b/src/volatility3/Dockerfile
@@ -114,10 +114,8 @@ RUN if [[ "${GIT_TAG_VOLATILITY3}" == "develop" ]]; then \
     python3 -m pip install --break-system-packages build; \
     python3 -m build; \
     else \
-    
     python3 -m pip install --break-system-packages .; \
     fi && \
-    
     chmod 0755 \
         vol.py \
         volatility3/framework/symbols/windows/pdbconv.py && \


### PR DESCRIPTION
This PR addresses two issues that prevent the Docker image from building and running correctly with recent versions of Volatility 3.

### 1\. Fixes Build Failure with Modern Volatility 3

**Problem:** The Docker build currently fails because it attempts to install dependencies using `requirements.txt` and then runs `python setup.py install`. Recent versions of Volatility 3 have adopted modern Python packaging standards (`pyproject.toml`) and no longer include these files.

**Solution:**

  - The installation process is updated to use `pip install .` which correctly handles the `pyproject.toml` configuration.
  - The redundant and failing `python setup.py install` command has been removed.

### 2\. Resolves Runtime Permission Errors

**Problem:** When running the container without an explicit `--workdir` flag, commands that generate output files (like `windows.dumpfiles`) fail with a `PermissionError: [Errno 13] Permission denied`.

**Reason:** The default `WORKDIR` was `/usr/local`, a system directory. The container's unprivileged user (`unprivileged`) does not have the necessary permissions to write to this location.

**Solution:**

  - A dedicated `/workspace` directory is now created during the build.
  - Ownership of `/workspace` is assigned to the `unprivileged` user.
  - `/workspace` is set as the final default `WORKDIR`.

These changes ensure the container works as expected out-of-the-box, making it more robust and user-friendly.